### PR TITLE
Fix subscribe-to-updates link focus state

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -115,3 +115,20 @@ To achieve the above look you can also use this CSS
   border: 0;
   box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
 }
+
+/*subscribe link selection focus */
+.updates-dropdown-container .updates-dropdown .updates-dropdown-nav a:focus,
+.updates-dropdown-container .updates-dropdown .updates-dropdown-nav button:focus{
+  box-shadow: 0 -2px #fd0, inset 0 -4px #0b0c0c !important;
+  outline: 0;
+  border: 0;
+  background: #fd0;
+  color: #0b0c0c !important;
+  outline: 0;
+  border: 0;
+}
+.updates-dropdown-container .updates-dropdown .updates-dropdown-nav a:focus span,
+.updates-dropdown-container .updates-dropdown .updates-dropdown-nav button:focus span {
+  filter: invert(1);
+  /* use filter because they load a different (dark) sprite from a url that would be fragile to use */
+}


### PR DESCRIPTION
Fixes white icon on yellow background focus state for subscribe-to-updated items

By default they're using two icon sprites (dark/white) for different states, but they're on cache-busting url which wouldn't be safe to reference, so we've resulted to using CSS filter to achieve a GOV.UK style focus state.


**Before**

<img width="312" alt="link-focus-before" src="https://github.com/user-attachments/assets/050bf372-d2ac-4a81-88a1-2fa220e152f4" />

<img width="311" alt="button-focus-before" src="https://github.com/user-attachments/assets/64bb3b82-6dd5-40d0-9b66-d071d38a96d4" />

**After**

<img width="320" alt="link-focus-after" src="https://github.com/user-attachments/assets/357178e0-2c52-4655-96b6-a740e1ad620d" />

<img width="317" alt="button-focus-after" src="https://github.com/user-attachments/assets/ecf2508e-5c61-436a-85c6-b0667f8f3c83" />


