### PR TITLE
Add link to the accessibility statement

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -1,3 +1,6 @@
+<div class="container">
+    <p><a href="#link-to-statement">Accessibility statement</a></p>
+</div>
 <script>
 $(function() {
   $('.components-container').removeClass('two-columns').addClass('one-column';

--- a/custom.css
+++ b/custom.css
@@ -150,3 +150,11 @@ To achieve the above look you can also use this CSS
   filter: invert(1);
   /* use filter because they load a different (dark) sprite from a url that would be fragile to use */
 }
+
+/* reduce page-footer margin if you add a custom footer*/
+/* page-footer has a default margin */
+/* and because custom footer gets appended after it */
+/* we need to reduce it */
+.page-footer {
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
Add link to the accessibility statement to the page footer via custom footer HTML option.

As the custom footer gets appended after the page footer which has a big bottom margin, we need to adjust it. Custom footer HTML makes use of the .container class which is what the page uses, so we can benefit from content alignment

![Screenshot 2025-06-18 at 16 07 28](https://github.com/user-attachments/assets/a705ba84-590e-46aa-9a24-c9cd50ddb7c9)
