### PR TITLE
Add missing autocomplete attributes

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -3,6 +3,19 @@
 </div>
 <script>
 $(function() {
-  $('.components-container').removeClass('two-columns').addClass('one-column';
+  $('.components-container').removeClass('two-columns').addClass('one-column');
+  // adds autocomplete attributes to controls that don't have one
+  var selectorAndAutocompleteAttributes = {
+    email: "email",
+    phone_country: "tel-country-code",
+    phone_number: "tel-national"
+  }
+
+  $.each(selectorAndAutocompleteAttributes, function(key, val) {
+    var $targetElements = $(`[name='${key}']`);
+    $.each($targetElements, function() {
+      $(this).attr('autocomplete', val);
+    });
+  });
 });
 </script>


### PR DESCRIPTION
Some controls are missing autocomplete attributes where they should have one. There are instances of two `input[name='email']` on a page, hence we store the elements in an array.

<img width="842" alt="Screenshot 2025-06-19 at 14 24 54" src="https://github.com/user-attachments/assets/247cbaaf-4a6f-482e-92f8-fe6d5282cc07" />

## How to test

- main page subscribe to updates
- create an incident, go to incident page and check subscribe to updates email form field
