### PR TITLE
Make incident report subheader visible on all viewports

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -171,3 +171,8 @@ To achieve the above look you can also use this CSS
         max-height: none !important;
     }
 }
+
+/* make subheader on incident page visible on smaller viewports/ zoom levels */
+.layout-content.status.status-incident .page-title .subheader:not(.scheduled-for) {
+    display: block;
+}


### PR DESCRIPTION
On smaller vieports or higher zoom levels, the subheader on the incident report page was set to be hidden. This change makes it always visible

**Before**
<img width="1236" alt="Screenshot 2025-06-20 at 11 05 03" src="https://github.com/user-attachments/assets/b9b45d31-6fb8-4a9c-be04-c380ae82e1c4" />

**After**
<img width="1242" alt="Screenshot 2025-06-20 at 11 04 52" src="https://github.com/user-attachments/assets/cc630267-11ca-490d-965c-6ea8474c34c9" />

