### PR TITLE
Update 'Subscribe to incident updates' with fixes

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -17,5 +17,10 @@ $(function() {
       $(this).attr('autocomplete', val);
     });
   });
+
+  // a11y fixes for subscribe to ongoing incident(s) button
+  $('.subscribe-button').attr('aria-haspopup', 'dialog').text(function() {
+    return this.text + ' for this incident';
+  });
 });
 </script>


### PR DESCRIPTION
Button is missing an 'aria-haspopup=dialog' attribute and button text is not entirely descriptive.

These two changes address that.

## How to test

- visit the [test](https://testgovuknotifytestarea.statuspage.io/incidents/f7vb1mzrz711) ongoing incident page and test script in dev tools