### PR TITLE
Fix 'subscribe to incident updates' popup display when zoomed in

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -158,3 +158,16 @@ To achieve the above look you can also use this CSS
 .page-footer {
     margin-bottom: 10px;
 }
+
+/* fix for subscribe to incident updates modal on mobile/zoom view */
+@media screen and (max-width: 580px) {
+    .modal-open-incident-subscribe.in {
+        margin-top: 0 !important;
+        overflow-y: auto !important;
+        bottom: 0 !important;
+    }
+
+    .modal .modal-body {
+        max-height: none !important;
+    }
+}


### PR DESCRIPTION
## What 
On mobile / zoomed-in view, the modal is partially cut-off and therefore unusable.

Fixes for mobile view include
- making whole modal scrollable
- removing large top margin
- removing height on the modal body which was previously scrollable

## How to test

- visit the [test](https://testgovuknotifytestarea.statuspage.io/incidents/f7vb1mzrz711) ongoing incident page and test script in dev tools