### PR TITLE
Trigger showing of all incidents for a given month

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -22,5 +22,8 @@ $(function() {
   $('.subscribe-button').attr('aria-haspopup', 'dialog').text(function() {
     return this.text + ' for this incident';
   });
+  
+  // expand / show all incidents in a given month
+  $('.expand-incidents').click().remove()
 });
 </script>

--- a/custom.css
+++ b/custom.css
@@ -126,15 +126,6 @@ To achieve the above look you can also use this CSS
   padding-bottom: 0.75rem;
 }
 
-/* show/collapse incidents toggle focus state */
-.layout-content.status.status-full-history .months-container .custom-focus:focus {
-  background: #fd0;
-  color: #0b0c0c;
-  outline: 0;
-  border: 0;
-  box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
-}
-
 /*subscribe link selection focus */
 .updates-dropdown-container .updates-dropdown .updates-dropdown-nav a:focus,
 .updates-dropdown-container .updates-dropdown .updates-dropdown-nav button:focus{


### PR DESCRIPTION
## What 
If there are more than X (3 I think) incidents in a given month, then status page only shows the first X. All the rest are not rendered and a "show all incidents" button is shown that upon click inserts remaining content above itself.

This isnt't how an expand/collapse should work, so it makes it inaccessible. As the content isn't there on page load we can't really make it work by shuffling elements around. Instead, we trigger the load of all incidents and remove the button(s). Also remove the button focus state as button no longer exists.

## Test
- https://status.notifications.service.gov.uk/history?page=21 has the toggle