### PR TITLE
Change headings

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -37,9 +37,13 @@ $(function() {
   $('.subscribe-button').attr('aria-haspopup', 'dialog').text(function() {
     return this.text + ' for this incident';
   });
+
+  function removeExpandIncidents () {
+    // expand / show all incidents in a given month
+    $('.expand-incidents').click().remove()
+  }
   
-  // expand / show all incidents in a given month
-  $('.expand-incidents').click().remove()
+  removeExpandIncidents();
 
   var $logo = document.querySelector('.page-name');
   var $container = document.querySelector('.layout-content > .container');
@@ -113,7 +117,10 @@ $(function() {
 
       updateIncidentsList();
 
-      var observer = new MutationObserver(updateIncidentsList);
+      var observer = new MutationObserver(() => {
+        updateIncidentsList()
+        removeExpandIncidents()
+      });
       observer.observe($incidentsList, { attributes: true, childList: true, subtree: true });
     }
 

--- a/custom-footer.html
+++ b/custom-footer.html
@@ -12,6 +12,7 @@ $(function() {
     "/incidents": ".incident-updates-container"
   };
 
+  // Add skiplink
   if (mainContainerMap.hasOwnProperty(pathRoot)) {
     document.querySelector(mainContainerMap[pathRoot]).setAttribute('id', 'main-content');
     document.body.insertAdjacentHTML('afterbegin', '<a href="#main-content" class="govuk-skip-link">Skip to main content</a>'); 
@@ -39,5 +40,83 @@ $(function() {
   
   // expand / show all incidents in a given month
   $('.expand-incidents').click().remove()
+
+  var $logo = document.querySelector('.page-name');
+  var $container = document.querySelector('.layout-content > .container');
+  var $pageFooter = document.querySelector('.page-footer');
+
+  function swapElForHTML ($oldEl, newHTML) {
+    $oldEl.insertAdjacentHTML('beforebegin', newHTML);
+    $oldEl.remove();
+  }
+
+  // Rewrite logo
+  if ($logo !== null) {
+     $logo.querySelector('a').textContent = 'GOV.UK Notify';
+  }
+
+  // Add heading to footer
+  if ($pageFooter !== null) {
+    $pageFooter.insertAdjacentHTML('afterbegin', '<h2 class="page-footer__heading govuk-visually-hidden">Support links</h2>');
+  }
+
+  // Home page specific
+  if ($container !== null) {
+    if (pathRoot === "/") {
+      var $aboutText = document.querySelector('.page-status + .text-section');
+      var $pageStatus = document.querySelector('.page-status');
+      var $pageStatusContent = $pageStatus.querySelector('h2');
+
+      if (($aboutText !== null) && ($pageStatus !== null) && ($pageStatusContent !== null)) {
+        // Add headings and move 'about' text
+        $container.insertAdjacentElement('afterbegin', $aboutText);
+        $container.insertAdjacentHTML('afterbegin', '<h1 class="font-x-largest">GOV.UK Notify status page</h1>');
+        $pageStatus.insertAdjacentHTML('beforebegin', '<h2 class="page-status__heading font-largest">Current status</h2>');
+
+        // Remake status overview from h2 to p
+        swapElForHTML($pageStatusContent, `<p class="${$pageStatusContent.className}">${$pageStatusContent.textContent}</p>`);
+
+        // Rewrite heading for incidents list to make it clear it includes today
+        document.querySelector('.incidents-list > h2:first-child').textContent = "Recent incidents";
+
+        // Reformat dates
+        document.querySelectorAll('.status-day > .date').forEach($el => {
+          if (/^[A-Za-z]+\s+\d{1,2},\s+\d{4}$/.test($el.textContent)) {
+            $textNodes = Array.from($el.childNodes).filter($el => $el.nodeType === 3);
+            $el.insertAdjacentElement('afterbegin', $el.querySelector('var:first-of-type'));
+            $textNodes[0].nodeValue = " " + $textNodes[0].nodeValue;
+            $textNodes[1].remove();
+          }
+        });
+      }
+    }
+
+    if (pathRoot === "/history") {
+      var $pageHeading = $container.querySelector('h4:first-child');
+      var $monthHeadings = $container.querySelectorAll('.month-title');
+
+      if ($pageHeading !== null) {
+        var pageHeadingText = $pageHeading.textContent;
+
+        // stop camel casing
+        $pageHeading.textContent = pageHeadingText[0].toUpperCase() + pageHeadingText.toLowerCase().slice(1);
+        swapElForHTML($pageHeading, `<h1 class="font-x-largest">${pageHeadingText}</h1>`);
+      }
+
+      if ($monthHeadings.length > 0) {
+        $monthHeadings.forEach($el => swapElForHTML($el, `<h2 class="${$el.className}">${$el.textContent}</h2>`));
+      }
+    }
+
+    if (pathRoot === "/incidents") {
+      var $affectedHeading = $container.querySelector('.components-affected');
+
+      if ($affectedHeading !== null) {
+        $affectedHeading.insertAdjacentHTML(
+          'afterbegin', '<h2 class="govuk-visually-hidden">Components affected</h2>'
+        );
+      }
+    }
+  }
 });
 </script>

--- a/custom-footer.html
+++ b/custom-footer.html
@@ -93,7 +93,7 @@ $(function() {
 
     if (pathRoot === "/history") {
       var $pageHeading = $container.querySelector('h4:first-child');
-      var $monthHeadings = $container.querySelectorAll('.month-title');
+      var $incidentsList = $container.querySelector('.months-container');
 
       if ($pageHeading !== null) {
         var pageHeadingText = $pageHeading.textContent;
@@ -103,9 +103,18 @@ $(function() {
         swapElForHTML($pageHeading, `<h1 class="font-x-largest">${pageHeadingText}</h1>`);
       }
 
-      if ($monthHeadings.length > 0) {
-        $monthHeadings.forEach($el => swapElForHTML($el, `<h2 class="${$el.className}">${$el.textContent}</h2>`));
+      function updateIncidentsList () {
+        var $monthHeadings = $incidentsList.querySelectorAll('h4.month-title');
+
+        if ($monthHeadings.length > 0) {
+          $monthHeadings.forEach($el => swapElForHTML($el, `<h2 class="${$el.className}">${$el.textContent}</h2>`));
+        }
       }
+
+      updateIncidentsList();
+
+      var observer = new MutationObserver(updateIncidentsList);
+      observer.observe($incidentsList, { attributes: true, childList: true, subtree: true });
     }
 
     if (pathRoot === "/incidents") {

--- a/custom.css
+++ b/custom.css
@@ -156,6 +156,10 @@ button:focus:not(:active):not(:hover) {
   display: none;
 }
 
+.text-section > p > a {
+  word-break:break-word;
+}
+
 .layout-content.status.status-index .page-status .last-updated-stamp {
   color: #fff;
 }
@@ -240,4 +244,14 @@ button:focus:not(:active):not(:hover) {
 
 h2.page-status__heading {
   margin-bottom: 20px;
+}
+
+/* make incident page content linear on mobile */
+.layout-content.status.status-incident .update-title,
+.layout-content.status.status-incident .update-container {
+  float: none;
+}
+
+.layout-content.status.status-incident  .update-container:not(.span12) {
+  width: auto;
 }

--- a/custom.css
+++ b/custom.css
@@ -247,11 +247,13 @@ h2.page-status__heading {
 }
 
 /* make incident page content linear on mobile */
-.layout-content.status.status-incident .update-title,
-.layout-content.status.status-incident .update-container {
-  float: none;
-}
+@media screen and (max-width: 450px) {
+  .layout-content.status.status-incident .update-title,
+  .layout-content.status.status-incident .update-container {
+    float: none;
+  }
 
-.layout-content.status.status-incident  .update-container:not(.span12) {
-  width: auto;
+  .layout-content.status.status-incident  .update-container:not(.span12) {
+    width: auto;
+  }
 }

--- a/custom.css
+++ b/custom.css
@@ -3,6 +3,20 @@ body {
   font-family: "Helvetica Neue", Helvetica, Arial, Sans-Serif;
 }
 
+.govuk-visually-hidden {
+  position:absolute!important;
+  width:1px!important;
+  height:1px!important;
+  margin:0!important;
+  padding:0!important;
+  overflow:hidden!important;
+  clip:rect(0 0 0 0)!important;
+  clip-path:inset(50%)!important;
+  border:0!important;
+  white-space:nowrap!important;
+  user-select:none
+}
+
 .font-small {
   font-size: 16px;
   line-height: 1.25em;
@@ -11,6 +25,15 @@ body {
 .font-regular {
   font-size: 19px;
   line-height: 1.25em;
+}
+
+.font-x-largest {
+  font-size: 36px;
+  line-height: 1.25em;
+
+  @media screen and (max-width: 650px) {
+    font-size: 27px;
+  }
 }
 
 a, a:hover {
@@ -213,4 +236,8 @@ button:focus:not(:active):not(:hover) {
 /* make subheader on incident page visible on smaller viewports/ zoom levels */
 .layout-content.status.status-incident .page-title .subheader:not(.scheduled-for) {
     display: block;
+}
+
+h2.page-status__heading {
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
Change the headings of all pages so they have a h1 matching the title and a hierarchy that labels the document structure.

https://trello.com/c/fVAVltqC/1404-status-page-add-headings-to-pages

This shows the home page after these changes but they also alter the headings on the history and incident pages.

<img width="1167" height="3030" alt="image" src="https://github.com/user-attachments/assets/2ad0d4da-0d5f-405f-bfc7-c03de9670c36" />

## Notes for reviewers

It's worth using a screen reader, even Voiceover will do, to see the headings for a page isolated from it, to check they make sense as an outline of the different sections.

<img width="808" height="574" alt="image" src="https://github.com/user-attachments/assets/4d1a71d2-0e05-415e-975e-8a5b174cc631" />
