### PR TITLE
Fix label with the wrong 'for' attribute

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -42,8 +42,10 @@ $(function() {
     // expand / show all incidents in a given month
     $('.expand-incidents').click().remove()
   }
-  
+
   removeExpandIncidents();
+
+  $('[for=otp]').attr('for', $('[name=otp]').attr('id'));
 
   var $logo = document.querySelector('.page-name');
   var $container = document.querySelector('.layout-content > .container');


### PR DESCRIPTION
Fix for an issue spotted by Chrome's excellent 'issues' checker:

<img width="469" height="257" alt="image" src="https://github.com/user-attachments/assets/0e2dcd40-da3a-4d82-a22a-1ea37bb96ac8" />

This screenshot shows the following:

> Chrome devtools open with an 'Issues' tab selected. Issue selected says:
> Incorrect use of <label for=FORM_ELEMENT>
> 
> The label's for attribute doesn't match any element id. This might prevent the browser from correctly autofilling the form > and accessibility tools from working correctly.
>
> To fix this issue, make sure the label's for attribute references the correct id of a form field.

## Notes for reviewers

Easiest way to see this dialog is to just hack the HTML in devtools. Note that Chrome's 'Issues' tab will still show issues even when fixed by our JS (so maybe just good, not excellent yet).