### PR TITLE
Fix dates links and headings

### DIFF
--- a/custom-footer.html
+++ b/custom-footer.html
@@ -54,6 +54,29 @@ $(function() {
     $oldEl.remove();
   }
 
+  function reformatDateRanges () {
+    function reformatRange ($range) {
+      if (/^[A-Za-z-]+\s+\d+,\s+\d+:\d+\s+-\s+([A-Za-z]+\s+\d+,\s+)?\d+:\d+\s+[A-Z]+$/.test($range.textContent)) {
+        var $dateVars = $range.querySelectorAll('var[data-var=date]');
+
+        $range.insertAdjacentElement('afterbegin', $dateVars[0]);
+        $range.childNodes[1].nodeValue = ' ' + $range.childNodes[1].nodeValue.trim();
+        if ($dateVars.length > 1) {
+          var $month = $dateVars[1].previousSibling;
+          $range.insertBefore($dateVars[1], $month);
+          $month.nodeValue = $month.nodeValue.replace(' - ', ' ');
+          $range.insertBefore(document.createTextNode(' - '), $dateVars[1]);
+        }
+      }
+    }
+
+    if (document.querySelector('.incident-list') !== null) {
+      var $incidentDateRanges = document.querySelectorAll('.incident-data > .secondary');
+
+      if ($incidentDateRanges !== null) { $incidentDateRanges.forEach($el => reformatRange($el)); }
+    }
+  }
+
   // Rewrite logo
   if ($logo !== null) {
      $logo.querySelector('a').textContent = 'GOV.UK Notify';
@@ -64,8 +87,11 @@ $(function() {
     $pageFooter.insertAdjacentHTML('afterbegin', '<h2 class="page-footer__heading govuk-visually-hidden">Support links</h2>');
   }
 
-  // Home page specific
   if ($container !== null) {
+
+    reformatDateRanges();
+
+    // Home page specific
     if (pathRoot === "/") {
       var $aboutText = document.querySelector('.page-status + .text-section');
       var $pageStatus = document.querySelector('.page-status');
@@ -107,7 +133,7 @@ $(function() {
         swapElForHTML($pageHeading, `<h1 class="font-x-largest">${pageHeadingText}</h1>`);
       }
 
-      function updateIncidentsList () {
+      function updateIncidentsListHeadings () {
         var $monthHeadings = $incidentsList.querySelectorAll('h4.month-title');
 
         if ($monthHeadings.length > 0) {
@@ -118,7 +144,8 @@ $(function() {
       updateIncidentsList();
 
       var observer = new MutationObserver(() => {
-        updateIncidentsList()
+        updateIncidentsListHeadings()
+        reformatDateRanges();
         removeExpandIncidents()
       });
       observer.observe($incidentsList, { attributes: true, childList: true, subtree: true });
@@ -133,6 +160,7 @@ $(function() {
         );
       }
     }
+
   }
 });
 </script>

--- a/custom-footer.html
+++ b/custom-footer.html
@@ -77,6 +77,23 @@ $(function() {
     }
   }
 
+  function makeSentenceCase (str) {
+    var trimmed = str.trim();
+    return trimmed[0].toUpperCase() + trimmed.slice(1).toLowerCase();
+  }
+
+  function getNodeByXPath (xpath) {
+    var result = document.evaluate(
+      xpath,
+      document,
+      null,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+      null,
+    );
+
+    return result.singleNodeValue;
+  }
+
   // Rewrite logo
   if ($logo !== null) {
      $logo.querySelector('a').textContent = 'GOV.UK Notify';
@@ -85,6 +102,11 @@ $(function() {
   // Add heading to footer
   if ($pageFooter !== null) {
     $pageFooter.insertAdjacentHTML('afterbegin', '<h2 class="page-footer__heading govuk-visually-hidden">Support links</h2>');
+    var $footerLinkText = getNodeByXPath("//div[contains(@class, 'page-footer')]/a/text()");
+
+    if ($footerLinkText !== null) {
+      $footerLinkText.nodeValue = ' ' + makeSentenceCase($footerLinkText.nodeValue);
+    }
   }
 
   if ($container !== null) {
@@ -126,11 +148,7 @@ $(function() {
       var $incidentsList = $container.querySelector('.months-container');
 
       if ($pageHeading !== null) {
-        var pageHeadingText = $pageHeading.textContent;
-
-        // stop camel casing
-        $pageHeading.textContent = pageHeadingText[0].toUpperCase() + pageHeadingText.toLowerCase().slice(1);
-        swapElForHTML($pageHeading, `<h1 class="font-x-largest">${pageHeadingText}</h1>`);
+        swapElForHTML($pageHeading, `<h1 class="font-x-largest">${makeSentenceCase($pageHeading.textContent)}</h1>`);
       }
 
       function updateIncidentsListHeadings () {
@@ -152,7 +170,12 @@ $(function() {
     }
 
     if (pathRoot === "/incidents") {
+      var $pageHeadingContextPrefix = getNodeByXPath("//h1/following-sibling::div[contains(@class, 'subheader')]/text()");
       var $affectedHeading = $container.querySelector('.components-affected');
+
+      if ($pageHeadingContextPrefix !== null) {
+        $pageHeadingContextPrefix.nodeValue = makeSentenceCase($pageHeadingContextPrefix.nodeValue) + ' ';
+      }
 
       if ($affectedHeading !== null) {
         $affectedHeading.insertAdjacentHTML(


### PR DESCRIPTION
Reformats incident date ranges to match the date format we use across Notify and on the homepage, for days.

Also rewrites camel-cased headings and links into sentence case.

All work from discussions with @karlchillmaid.

## Notes for reviewers

Sorry about the regex and xpath.