### PR TITLE
Review colours - adjustments

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -202,15 +202,6 @@ button:focus:not(:active):not(:hover) {
   padding: 15px 0;
 }
 
-
-.layout-content.status-full-history .month .incident-container .impact-major {
-   color: #BD0812;
-}
-
-.layout-content.status-incident .incident-name.impact-major{
-  color: #BD0812 !important;
-}
-
 .page-footer { 
   padding-bottom: 0.75rem; /* adjust footer padding so that links get full underline */
 

--- a/custom.css
+++ b/custom.css
@@ -51,6 +51,10 @@ a:focus {
   text-decoration: none !important;
 }
 
+a.secondary {
+  color: #1D70B8;
+}
+
 button:focus {
   border-color: #ffdd00 !important;
   color: #0b0c0c !important;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
       {
         "files": "**/*.css",
         "rules": {
-          "declaration-no-important": null
+          "declaration-no-important": null,
+          "selector-no-qualifying-type": null
         }
       }
     ]


### PR DESCRIPTION
## What 
We have had a look at the colours related to the statuses and components in https://trello.com/c/cJVIoYRP/1428-status-page-review-colours and have decided to make the following changes:

1. remove current CSS `color: #BD0812` override for major incident links
2. turn grey links into blue
3. adjust “yellows” `#B1610C` to `#9D6914` for delineation between the current two oranges for minor and major (contrast ration 4.7)

1 and 2 are done in this PR. 3. will be done in the StatusPage admin once reviewed here

## Visual changes

### Major and critical links

**Before**
<img width="367" height="301" alt="Screenshot 2025-08-17 at 18 42 22" src="https://github.com/user-attachments/assets/5b4865c5-190b-41b7-901e-e7ac6ee4cef6" />

**After**
<img width="377" height="331" alt="new-colours-links" src="https://github.com/user-attachments/assets/7d31d343-b4ee-483d-b3e7-237fbf4630c8" />


### Homepage current status bar

**Before** 
(fix did not override the heading, it remained as set in the admin)
<img width="359" height="367" alt="Screenshot 2025-08-17 at 18 31 40" src="https://github.com/user-attachments/assets/478c6f5b-8def-4a44-8208-93f98aa6ad7b" />

**After**
<img width="363" height="380" alt="Screenshot 2025-08-17 at 18 20 02" src="https://github.com/user-attachments/assets/df450d17-5b96-4407-85a3-13c53a1432fd" />

### Component status

**Before**
<img width="721" height="236" alt="Screenshot 2025-08-17 at 18 36 34" src="https://github.com/user-attachments/assets/cb7f4ccf-d50a-4af3-95b0-ae6a3107d2ec" />

**After**
<img width="717" height="241" alt="Screenshot 2025-08-17 at 18 39 44" src="https://github.com/user-attachments/assets/a59f83ef-ef19-461d-9cbe-4990d9d1468b" />

### Secondary colour links colour change

**Before**
<img width="525" height="169" alt="Screenshot 2025-08-17 at 18 43 44" src="https://github.com/user-attachments/assets/f4096194-f175-43cf-bd12-a0864ae2bba8" />

**After**
<img width="520" height="204" alt="Screenshot 2025-08-17 at 18 44 46" src="https://github.com/user-attachments/assets/6cd06b34-3335-4235-9d49-17314f5af016" />


