### PR TITLE
Signpost incident type and component status

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run test:only
 To run a single selected test when the server is running, you can run
 
 ```bash
-npx wdio run ./tests/config.js --spec tests/home-page.spec.js
+npx wdio run ./tests/config.js --spec tests/home-page.spec.mjs
 ```
 
 ## Linting

--- a/custom-footer.js
+++ b/custom-footer.js
@@ -160,6 +160,32 @@ $(function () {
         // Rewrite heading for incidents list to make it clear it includes today
         document.querySelector('.incidents-list > h2:first-child').textContent = 'Recent incidents'
 
+        // make components list an actual semantic list
+        // adds aria-describedby to the component name container to announce the status
+        // adds visually hiddent 'status' and 'comppnent' texts
+        const $componentContainer = document.querySelector('.components-container')
+        swapElForHTML(document.querySelector('.components-container'), `<ul class="${$componentContainer.className}">${$componentContainer.innerHTML}</ul>`)
+        const $newComponentContainer = document.querySelector('.components-container')
+        const $components = $newComponentContainer.querySelectorAll('.component-container')
+        $components.forEach($el => {
+          const classes = $el.className
+          const $componentName = $el.querySelector('.name')
+          const $componentStatus = $el.querySelector('.component-status')
+          const componentStatusClasses = $el.querySelector('.component-inner-container').className
+          const $listElement = `
+          <li class="${classes} ${componentStatusClasses}">
+            <span class="${$componentName.className}">
+              <span class="govuk-visually-hidden">component name: </span>
+              ${$componentName.textContent}
+            </span>
+            <span class="${$componentStatus.className}">
+              <span class="govuk-visually-hidden">status: </span>
+              ${$componentStatus.textContent}
+            </span>
+          </li>`
+          swapElForHTML($el, $listElement)
+        })
+
         // Reformat dates
         document.querySelectorAll('.status-day > .date').forEach($el => {
           if (/^[A-Za-z]+\s+\d{1,2},\s+\d{4}$/.test($el.textContent)) {

--- a/custom.css
+++ b/custom.css
@@ -240,6 +240,16 @@ button:focus:not(:active):not(:hover) {
   margin-bottom: 20px;
 }
 
+/* our incident descriptor on incident and history pages */
+.incident-level {
+  font-weight: 400;
+}
+
+/* left-align page title and subheader */
+.layout-content.status.status-incident .page-title {
+  text-align: left;
+}
+
 /* make incident page content linear on mobile */
 @media screen and (max-width: 450px) {
   .layout-content.status.status-incident .update-title,

--- a/tests/history-page.spec.mjs
+++ b/tests/history-page.spec.mjs
@@ -44,4 +44,25 @@ describe('History page', () => {
       }
     });
   });
+
+  describe("incident list link", () => {
+    it('should have incident type descriptor below the link and be linked to it vis aria-describedby ', async () => {
+      const incidentLevelMap = {
+        'impact-none': 'No incident',
+        'impact-maintenance': 'Maintenance',
+        'impact-minor': 'Minor incident',
+        'impact-major': 'Major incident',
+        'impact-critical': 'Critical incident'
+      }
+      for await (const el of $$('.incident-data > a')) {
+        const impactLevelClass = (await el.getAttribute('class')).split(" ")[0]
+        const incidentDescriptorElemement = await el.nextElement()
+        const elementAria = await el.getAttribute('aria-describedby')
+        const descriptorElementAria = await incidentDescriptorElemement.getAttribute('id')
+
+        await expect(await incidentDescriptorElemement.getText()).toBe(incidentLevelMap[impactLevelClass])
+        await expect(await elementAria).toBe(descriptorElementAria)
+      }
+    });
+  });
 });

--- a/tests/home-page.spec.mjs
+++ b/tests/home-page.spec.mjs
@@ -89,6 +89,28 @@ describe('Homepage', () => {
     });
   });
 
+  describe("incident list link", () => {
+    it('should have incident type descriptor below the link and be linked to it vis aria-describedby ', async () => {
+      const incidentLevelMap = {
+        'impact-none': 'No incident',
+        'impact-maintenance': 'Maintenance',
+        'impact-minor': 'Minor incident',
+        'impact-major': 'Major incident',
+        'impact-critical': 'Critical incident'
+      }
+      for await (const el of $$('.incident-title')) {
+        const impactLevelClass = (await el.getAttribute('class')).split(" ")[1]
+        const incidentLink = await el.$('a')
+        const incidentDescriptorElemement = await el.$('.incident-level')
+        const elementAria = await incidentLink.getAttribute('aria-describedby')
+        const descriptorElementAria = await incidentDescriptorElemement.getAttribute('id')
+
+        await expect(await incidentDescriptorElemement.getText()).toBe(incidentLevelMap[impactLevelClass])
+        await expect(await elementAria).toBe(descriptorElementAria)
+      }
+    });
+  });
+
   // these are present on all pages so they'll only be tested once here
   describe("page footer", () => {
     it('should have a hidden h2 that says "Support links"', async () => {

--- a/tests/home-page.spec.mjs
+++ b/tests/home-page.spec.mjs
@@ -56,6 +56,24 @@ describe('Homepage', () => {
     });
   });
 
+  describe("component status list", () => { 
+    it('has been converted to an unordered list', async () => {
+      await expect(await $('.components-container').getTagName()).toBe('ul');
+    });
+  });
+
+  describe("component status list items", () => { 
+    it('have been converted to an a list item and contain component name, status and visually hidden status descriptor', async () => {
+      for await (const el of $$('.component-inner-container')) {
+         await expect(await el.getTagName()).toBe('li');
+         await expect(await el.$('.name')).toBeExisting();
+         await expect(await el.$('.component-status')).toBeExisting();
+         await expect(await el.$('.component-status span')).toHaveElementClass('govuk-visually-hidden');
+         await expect(await el.$('.component-status span')).toHaveText('status:')
+      }
+    });
+  });
+
   describe("incidents list", () => {
     it('should have a h2 that says "Recent incidents"', async () => {
       await expect($('.incidents-list > h2:first-child')).toHaveText('Recent incidents');

--- a/tests/incident-page.spec.mjs
+++ b/tests/incident-page.spec.mjs
@@ -1,7 +1,7 @@
 import { expect, browser, $ } from '@wdio/globals';
 import { serverConfig } from '../server/config.mjs';
 
-describe('History page', () => {
+describe('Incident page', () => {
 
   beforeAll( async () => {
     await browser.url(`http://${serverConfig.hostname}:${serverConfig.port}/incidents`);
@@ -28,6 +28,21 @@ describe('History page', () => {
     it('is preceded by a visually hidden heading that says "Components affected"', async () => {
       const componentAffectedSection = $('.components-affected > h2');
       await expect(await componentAffectedSection.getText()).toContain('Components affected');
+    });
+  });
+
+  describe("incident heading", () => {
+    it('should should contain the type of incident it is', async () => {
+      const incidentLevelMap = {
+        'impact-none': 'No incident',
+        'impact-maintenance': 'Maintenance',
+        'impact-minor': 'Minor incident',
+        'impact-major': 'Major incident',
+        'impact-critical': 'Critical incident'
+      }
+      const pageTitle = $('.page-title > h1')
+      const impactLevelClass = (await pageTitle.getAttribute('class')).split(" ").pop()
+      await expect(await pageTitle.getText()).toContain(incidentLevelMap[impactLevelClass])
     });
   });
 


### PR DESCRIPTION
## What
Incidents and status of components are currently only identified by colour - https://trello.com/c/ari5FjHW/1425-status-page-status-colours-convey-meaning

This pull request addresses this by
1. adding a descriptor to the incident in the list on the history page and then also 
2.  adding a descriptor to into the heading on the incident page
3.  updating component list semantics to a screenreader-accessible markup and adding context  to each component name and status.
<img width="437" height="79" alt="Screenshot 2025-08-28 at 11 16 59" src="https://github.com/user-attachments/assets/ddf24ce8-d282-45f0-94b8-315aeb1a8bfb" />


## Visual changes
### History page
<img width="724" height="1735" alt="history page" src="https://github.com/user-attachments/assets/b7a74e1f-733a-407c-a6b9-f58e210e3f3b" />

### Incident page
<img width="1462" height="1850" alt="incident page" src="https://github.com/user-attachments/assets/2f6ca6f0-6d57-419e-afdd-17e763f25baf" />

### Homepage component list
<img width="1137" height="489" alt="Screenshot 2025-08-23 at 17 06 20" src="https://github.com/user-attachments/assets/d4f749a0-1162-44b5-b8b0-2250bf163d66" />

