### PR TITLE
Fix custom footer styling on incident page

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -218,6 +218,20 @@ button:focus:not(:active):not(:hover) {
   margin-bottom: 10px;
 }
 
+/* footer of the incident page has special width and padding
+ * compared to other page, so to make the custom footer container fit well, 
+ * we need to adjust the width and the margin of its container element
+*/
+.layout-content.status.status-incident>.container + .custom-footer-container .container {
+  max-width: 600px;
+  margin-top: -70px;
+}
+@media screen and (max-width: 650px) {
+  .layout-content.status.status-incident>.container + .custom-footer-container .container {
+    margin-top: -10%;
+  }
+}
+
 /* fix for subscribe to incident updates modal on mobile/zoom view */
 @media screen and (max-width: 580px) {
     .modal-open-incident-subscribe.in {


### PR DESCRIPTION
Footer of the incident page has special width and padding compared to other page, so to make the custom footer container fit well,  we need to adjust the width and the margin of its container element.

Before
<img width="944" height="296" alt="Screenshot 2025-09-10 at 11 35 26" src="https://github.com/user-attachments/assets/3d19d9ee-0e9a-4da7-bdef-9675d5c6795e" />


After
<img width="644" height="209" alt="Screenshot 2025-09-10 at 11 33 19" src="https://github.com/user-attachments/assets/1e7598cb-07f0-4602-80a5-947678e9d8e3" />
